### PR TITLE
fix: port is returned as a string

### DIFF
--- a/providers/abstract.go
+++ b/providers/abstract.go
@@ -68,7 +68,7 @@ type Identity struct {
 // ResourceInfo struct represents information about a resource
 type ResourceInfo struct {
 	Host        string                 `json:"host"`
-	Port        int                    `json:"port"`
+	Port        string                 `json:"port"`
 	Type        string                 `json:"type"`
 	Protocol    string                 `json:"protocol"`
 	Options     map[string]interface{} `json:"options"`

--- a/providers/kubernetes_test.go
+++ b/providers/kubernetes_test.go
@@ -15,7 +15,7 @@ func TestKubernetesConfigProvider(t *testing.T) {
 	os.Setenv("KAPETA_PROVIDER_PORT_REST", "8080")
 	os.Setenv("KAPETA_PROVIDER_HOST", "localhost")
 	os.Setenv("KAPETA_CONSUMER_SERVICE_TEST_SERVICE_REST", "http://test-service:8080")
-	os.Setenv("KAPETA_CONSUMER_RESOURCE_TEST_RESOURCE_REST", `{"host": "test-resource", "port": 9090, "type": "test", "protocol": "http"}`)
+	os.Setenv("KAPETA_CONSUMER_RESOURCE_TEST_RESOURCE_REST", `{"host": "test-resource", "port": "9090", "type": "test", "protocol": "http"}`)
 	os.Setenv("KAPETA_INSTANCE_CONFIG", `{"exampleField": "exampleValue"}`)
 	os.Setenv("KAPETA_BLOCK_HOSTS", `{"test-instance": "test-host"}`)
 
@@ -127,8 +127,8 @@ func TestK8sGetServiceAddress(t *testing.T) {
 }
 
 func TestK8sGetResourceInfo(t *testing.T) {
-	os.Setenv("KAPETA_CONSUMER_RESOURCE_FOO_REST", "{\"host\": \"10.0.0.1\", \"port\": 8080}")
-	os.Setenv("KAPETA_CONSUMER_RESOURCE_BAR_GRPC", "{\"host\": \"10.0.0.2\", \"port\": 8081}")
+	os.Setenv("KAPETA_CONSUMER_RESOURCE_FOO_REST", "{\"host\": \"10.0.0.1\", \"port\": \"8080\"}")
+	os.Setenv("KAPETA_CONSUMER_RESOURCE_BAR_GRPC", "{\"host\": \"10.0.0.2\", \"port\": \"8081\"}")
 
 	provider := NewKubernetesConfigProvider("block-ref", "system-id", "instance-id", map[string]interface{}{
 		"type": "kubernetes",
@@ -137,12 +137,12 @@ func TestK8sGetResourceInfo(t *testing.T) {
 	info, err := provider.GetResourceInfo("foo", "rest", "foo")
 	assert.NoError(t, err)
 	assert.Equal(t, "10.0.0.1", info.Host)
-	assert.Equal(t, 8080, info.Port)
+	assert.Equal(t, "8080", info.Port)
 
 	info, err = provider.GetResourceInfo("foo", "grpc", "bar")
 	assert.NoError(t, err)
 	assert.Equal(t, "10.0.0.2", info.Host)
-	assert.Equal(t, 8081, info.Port)
+	assert.Equal(t, "8081", info.Port)
 
 	_, err = provider.GetResourceInfo("foo", "rest", "baz")
 	assert.Error(t, err)

--- a/providers/local.go
+++ b/providers/local.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/kapetacom/schemas/packages/go/model"
 	"io"
 	"net/http"
 	"net/url"
@@ -15,6 +14,8 @@ import (
 	"os/signal"
 	"strings"
 	"syscall"
+
+	"github.com/kapetacom/schemas/packages/go/model"
 
 	cfg "github.com/kapetacom/sdk-go-config/config"
 )
@@ -158,7 +159,8 @@ func (l *LocalConfigProvider) RegisterInstanceWithLocalClusterService() error {
 	}
 	defer response.Body.Close()
 	if (response.StatusCode < 200) || (response.StatusCode > 299) {
-		return fmt.Errorf("failed to register instance: %d", response.StatusCode)
+		d, _ := io.ReadAll(response.Body)
+		return fmt.Errorf("failed to register instance: %v\n\t%v", response.Status, string(d))
 	}
 	exitHandler := func() {
 		l.InstanceStopped()
@@ -196,7 +198,7 @@ func (l *LocalConfigProvider) GetResourceInfo(resourceType, portType, resourceNa
 	resourceInfo := &ResourceInfo{}
 	d, err := l.getRequestRaw(url)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get resource info: %w", err)
+		return nil, fmt.Errorf("failed to get resource info: %w from %v", err, url)
 	}
 	err = json.Unmarshal(d, resourceInfo)
 	if err != nil {


### PR DESCRIPTION
The port returned from the local cluster service is a string.